### PR TITLE
Add gcc for compatibility reasons

### DIFF
--- a/gnat-fsf-8.3/Dockerfile
+++ b/gnat-fsf-8.3/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:buster
 
 RUN apt-get update \
     && apt-get install -y \
+        gcc \
         gnat \
         gprbuild \
         libaunit18-dev \


### PR DESCRIPTION
I'm checking the GCC version in the runtime with `gcc -dumpversion`. The `gnat` package doesn't include `gcc` but only `gnatgcc`. Since the community GNAT does not come with `gnatgcc` I think we should install `gcc` in the FSF GNAT container.